### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -3,6 +3,8 @@ run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 on: [push]
 jobs:
   Explore-GitHub-Actions:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."


### PR DESCRIPTION
Potential fix for [https://github.com/Alcheri/GoogleMaps/security/code-scanning/2](https://github.com/Alcheri/GoogleMaps/security/code-scanning/2)

The fix is to add an explicit `permissions` block restricting the GITHUB_TOKEN to the minimal required scope. Since this workflow only checks out the repo and runs shell commands that don’t write to GitHub resources, `contents: read` is sufficient. To avoid changing existing behavior and to scope permissions as narrowly as possible, we can add `permissions` at the job level for `Explore-GitHub-Actions`, directly above `runs-on`.

Concretely, edit `.github/workflows/github-actions-demo.yml` so that under `Explore-GitHub-Actions:` you insert:

```yaml
    permissions:
      contents: read
```

This leaves all existing steps and behavior intact while ensuring the job’s GITHUB_TOKEN cannot perform write operations on repository contents (or other resources not explicitly granted).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
